### PR TITLE
Add simple Node.js test

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,4 +12,11 @@ kotlin {
             binaries.executable()
         }
     }
+    sourceSets {
+        val jsTest by getting {
+            dependencies {
+                implementation(kotlin("test"))
+            }
+        }
+    }
 }

--- a/src/jsMain/kotlin/Main.kt
+++ b/src/jsMain/kotlin/Main.kt
@@ -1,4 +1,8 @@
-fun main() {
+fun greetMessage(): String {
     val message = listOf("Hello", "from", "Kotlin", "on", "Node.js!")
-    println("Hello from Kotlin on Node.js! $message")
+    return "Hello from Kotlin on Node.js! $message"
+}
+
+fun main() {
+    println(greetMessage())
 }

--- a/src/jsTest/kotlin/MainTest.kt
+++ b/src/jsTest/kotlin/MainTest.kt
@@ -1,0 +1,10 @@
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class MainTest {
+    @Test
+    fun testGreetMessage() {
+        val expected = "Hello from Kotlin on Node.js! [Hello, from, Kotlin, on, Node.js!]"
+        assertEquals(expected, greetMessage())
+    }
+}


### PR DESCRIPTION
## Summary
- add function to return greeting string and adjust main
- configure jsTest dependencies
- add Kotlin/JS unit test for greetMessage

## Testing
- `./gradlew jsTest --console=plain`

------
https://chatgpt.com/codex/tasks/task_e_6844108c3138832481d4e2438458ebd5